### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pysnmp >= 7.1.4
 cryptography >= 43.0.1
-pysnmp-mib
-psutils
+pysnmp-mibs
+psutil


### PR DESCRIPTION
No modules called pysnmp-mib or psutils. Correct modules are pysnmp-mibs and psutil